### PR TITLE
make guard watch slang sources

### DIFF
--- a/src/templates/Guardfile.ecr
+++ b/src/templates/Guardfile.ecr
@@ -1,6 +1,7 @@
 # Watches your main kemal app
 guard "kemal", path: ".", file: "app.cr" do
   watch("src/<%= name %>.cr")
+  watch(%r{src/.*\.slang})
 end
 
 # Watches your sass files


### PR DESCRIPTION
The first thing I tried after launching my first fez-generated app is to change a slang template expecting for a reload to no avail.

Since slang sources are processed in compile time, guard should track changes on them.
