### PR TITLE
Fixed template, this repo has moved

### DIFF
--- a/src/templates/api/shard.yml_tmpl
+++ b/src/templates/api/shard.yml_tmpl
@@ -20,5 +20,5 @@ development_dependencies:
     github: sdogruyol/spec-kemal
     branch: master
   icr:
-    github: greyblake/crystal-icr
+    github: crystal-community/icr
     branch: master

--- a/src/templates/ecr/shard.yml_tmpl
+++ b/src/templates/ecr/shard.yml_tmpl
@@ -16,5 +16,5 @@ development_dependencies:
     github: sdogruyol/spec-kemal
     branch: master
   icr:
-    github: greyblake/crystal-icr
+    github: crystal-community/icr
     branch: master

--- a/src/templates/slang/shard.yml_tmpl
+++ b/src/templates/slang/shard.yml_tmpl
@@ -20,5 +20,5 @@ development_dependencies:
     github: sdogruyol/spec-kemal
     branch: master
   icr:
-    github: greyblake/crystal-icr
+    github: crystal-community/icr
     branch: master


### PR DESCRIPTION
Hi Jeremy, I tried to create a new API using Fez, and I ran into this issue

    Failed to find icr version for git refs=master

It looks like that repo got moved to [this other Github page](https://github.com/crystal-community/icr), so I created this PR to fix this issue.

Thanks!