### PR TITLE
Create an empty ".env" file

### DIFF
--- a/spec/application_spec.cr
+++ b/spec/application_spec.cr
@@ -1,14 +1,18 @@
 require "./spec_helper"
 spec_source "application"
 
+TMP_SAMPLE_DIR = "/tmp/sample_site"
+TMP_SAMPLE_APP = "/tmp/sample_app"
+
 describe Fez::Application do
   describe ".build_directory" do
     Spec.before_each do
-      Dir.mkdir_p("/tmp/sample_app")
+      Dir.mkdir_p(TMP_SAMPLE_APP)
     end
 
     Spec.after_each do
-      FileUtils.rm_r("/tmp/sample_app")
+      FileUtils.rm_r(TMP_SAMPLE_APP)
+      FileUtils.rm_r(TMP_SAMPLE_DIR) if Dir.exists?(TMP_SAMPLE_DIR)
     end
 
     it "raises an error when the directory exists" do
@@ -20,9 +24,18 @@ describe Fez::Application do
 
     it "creates a new directory in /tmp/sample_app/site" do
       app = Fez::Application.new("site")
-      app.build_directory("/tmp/sample_site")
-      Dir.exists?("/tmp/sample_site").should eq true
-      FileUtils.rm_r("/tmp/sample_site")
+      app.build_directory(TMP_SAMPLE_DIR)
+      Dir.exists?(TMP_SAMPLE_DIR).should eq true
+    end
+
+    it "creates an empty .env file on project's root directory" do
+      app = Fez::Application.new("site")
+      root_dir_path = TMP_SAMPLE_DIR
+      env_path = File.join(root_dir_path, ".env")
+      app.build_directory(root_dir_path)
+      app.build_project(Fez::DefaultOptions.template.as(String))
+      Dir.exists?(TMP_SAMPLE_DIR).should eq true
+      File.exists?(env_path).should eq true
     end
   end
 end

--- a/src/fez/application.cr
+++ b/src/fez/application.cr
@@ -1,5 +1,7 @@
 module Fez
   class Application
+    ENV = ".env"
+
     getter name : String
     getter directory : String
 
@@ -67,6 +69,13 @@ module Fez
         })
         File.delete tmpl_file
       end
+
+      create_empty_env
+    end
+
+    def create_empty_env
+      env = File.join(@directory, ENV)
+      File.new(env, "w") unless File.exists?(env)
     end
   end
 end


### PR DESCRIPTION
After creating a new API and running it for the first time, you get this error:

```
crystal app.cr
Unhandled exception: Error opening file '.env' with mode 'r': No such file or directory (Errno)
  from /usr/local/Cellar/crystal/0.33.0/src/crystal/system/unix/file.cr:10:7 in 'open'
  from /usr/local/Cellar/crystal/0.33.0/src/file.cr:107:5 in 'new'
  from /usr/local/Cellar/crystal/0.33.0/src/file.cr:601:5 in 'read_lines'
  from /usr/local/Cellar/crystal/0.33.0/src/file.cr:658:3 in 'read_lines'
  from /usr/local/Cellar/crystal/0.33.0/src/indexable.cr:266:5 in '__crystal_main'
  from /usr/local/Cellar/crystal/0.33.0/src/crystal/main.cr:106:5 in 'main_user_code'
  from /usr/local/Cellar/crystal/0.33.0/src/crystal/main.cr:92:7 in 'main'
  from /usr/local/Cellar/crystal/0.33.0/src/crystal/main.cr:115:3 in 'main'
make: *** [run] Error 1
```

Creating an empty `.env` file fixes it, so I wonder if it makes sense that Fez creates it.