### PR TITLE
read .env when file exists

### DIFF
--- a/src/templates/api/config.cr_tmpl
+++ b/src/templates/api/config.cr_tmpl
@@ -4,11 +4,12 @@ require "kave"
 require "./src/macros/*"
 require "./src/{{name}}.cr"
 
-File.read_lines(".env").each do |line|
-  key, value = line.strip.split "="
-  ENV[key] = value
+if File.exists?(".env")
+  File.read_lines(".env").each do |line|
+    key, value = line.strip.split "="
+    ENV[key] = value
+  end
 end
-
 
 Kave.configure do |c|
   # use default options

--- a/src/templates/ecr/config.cr_tmpl
+++ b/src/templates/ecr/config.cr_tmpl
@@ -4,7 +4,9 @@ require "kemal"
 require "./src/macros/*"
 require "./src/{{name}}.cr"
 
-File.read_lines(".env").each do |line|
-  key, value = line.strip.split "="
-  ENV[key] = value
+if File.exists?(".env")
+  File.read_lines(".env").each do |line|
+    key, value = line.strip.split "="
+    ENV[key] = value
+  end
 end

--- a/src/templates/slang/config.cr_tmpl
+++ b/src/templates/slang/config.cr_tmpl
@@ -4,7 +4,9 @@ require "kilt/slang"
 require "./src/macros/*"
 require "./src/{{name}}.cr"
 
-File.read_lines(".env").each do |line|
-  key, value = line.strip.split "="
-  ENV[key] = value
+if File.exists?(".env")
+  File.read_lines(".env").each do |line|
+    key, value = line.strip.split "="
+    ENV[key] = value
+  end
 end


### PR DESCRIPTION
Hi, this is second time for me to send PR to fez.

Now, `config.cr` always reads `.env`, so if I add `.env` to `.gitignore`, my app raises error and doesn't work in production because there're no `.env`.
I think `.env` file is usually used in development, so this behavior is not desirable.
I believe reading `.env` only when the file exists is good for both people(who want to use .env in production, and who don't).
Thank you.